### PR TITLE
Replace time with chrono

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -261,6 +261,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0942ffc6dcaadf03badf6e6a2d0228460359d5e34b57ccdc720b7382dfbd5ec5"
 
 [[package]]
+name = "android-tzdata"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e999941b234f3131b00bc13c22d06e8c5ff726d1b6318ac7eb276997bbb4fef0"
+
+[[package]]
+name = "android_system_properties"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "819e7219dbd41043ac279b19830f2efc897156490d7fd6ea916720117ee66311"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "arrayvec"
 version = "0.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -431,6 +446,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
+name = "chrono"
+version = "0.4.30"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "defd4e7873dbddba6c7c91e199c7fcb946abc4a6a4ac3195400bcfb01b5de877"
+dependencies = [
+ "android-tzdata",
+ "iana-time-zone",
+ "js-sys",
+ "num-traits",
+ "serde",
+ "wasm-bindgen",
+ "windows-targets",
+]
+
+[[package]]
 name = "const-oid"
 version = "0.9.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -452,6 +482,12 @@ dependencies = [
  "time",
  "version_check",
 ]
+
+[[package]]
+name = "core-foundation-sys"
+version = "0.8.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e496a50fda8aacccc86d7529e2c1e0892dbd0f898a6b5645b5561b89c3210efa"
 
 [[package]]
 name = "cpufeatures"
@@ -531,9 +567,6 @@ name = "deranged"
 version = "0.3.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f2696e8a945f658fd14dc3b87242e6b80cd0f36ff04ea560fa39082368847946"
-dependencies = [
- "serde",
-]
 
 [[package]]
 name = "derive_more"
@@ -903,6 +936,29 @@ name = "humantime"
 version = "2.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9a3a5bfb195931eeb336b2a7b4d761daec841b97f947d34394601737a7bba5e4"
+
+[[package]]
+name = "iana-time-zone"
+version = "0.1.57"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2fad5b825842d2b38bd206f3e81d6957625fd7f0a361e345c30e01a0ae2dd613"
+dependencies = [
+ "android_system_properties",
+ "core-foundation-sys",
+ "iana-time-zone-haiku",
+ "js-sys",
+ "wasm-bindgen",
+ "windows",
+]
+
+[[package]]
+name = "iana-time-zone-haiku"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f31827a206f56af32e590ba56d5d2d085f558508192593743f16b2306495269f"
+dependencies = [
+ "cc",
+]
 
 [[package]]
 name = "idna"
@@ -1623,6 +1679,7 @@ version = "0.2.1"
 dependencies = [
  "actix-web",
  "awc",
+ "chrono",
  "dotenvy",
  "env_logger",
  "log",
@@ -1634,7 +1691,6 @@ dependencies = [
  "serde_urlencoded",
  "sha2",
  "sqlx",
- "time",
  "uuid",
 ]
 
@@ -1722,6 +1778,7 @@ dependencies = [
  "atoi",
  "byteorder",
  "bytes",
+ "chrono",
  "crc",
  "crossbeam-queue",
  "dotenvy",
@@ -1748,7 +1805,6 @@ dependencies = [
  "smallvec",
  "sqlformat",
  "thiserror",
- "time",
  "tokio",
  "tokio-stream",
  "tracing",
@@ -1807,6 +1863,7 @@ dependencies = [
  "bitflags 2.4.0",
  "byteorder",
  "bytes",
+ "chrono",
  "crc",
  "digest",
  "dotenvy",
@@ -1834,7 +1891,6 @@ dependencies = [
  "sqlx-core",
  "stringprep",
  "thiserror",
- "time",
  "tracing",
  "uuid",
  "whoami",
@@ -1850,6 +1906,7 @@ dependencies = [
  "base64",
  "bitflags 2.4.0",
  "byteorder",
+ "chrono",
  "crc",
  "dotenvy",
  "etcetera",
@@ -1875,7 +1932,6 @@ dependencies = [
  "sqlx-core",
  "stringprep",
  "thiserror",
- "time",
  "tracing",
  "uuid",
  "whoami",
@@ -1888,6 +1944,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "be4c21bf34c7cae5b283efb3ac1bcc7670df7561124dc2f8bdc0b59be40f79a2"
 dependencies = [
  "atoi",
+ "chrono",
  "flume",
  "futures-channel",
  "futures-core",
@@ -1899,7 +1956,6 @@ dependencies = [
  "percent-encoding",
  "serde",
  "sqlx-core",
- "time",
  "tracing",
  "url",
  "uuid",
@@ -2326,6 +2382,15 @@ name = "winapi-x86_64-pc-windows-gnu"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
+
+[[package]]
+name = "windows"
+version = "0.48.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e686886bc078bc1b0b600cac0147aadb815089b6e4da64016cbd754b6342700f"
+dependencies = [
+ "windows-targets",
+]
 
 [[package]]
 name = "windows-sys"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,6 +12,7 @@ repository = "https://github.com/ikornaselur/similarium-rs"
 [dependencies]
 actix-web = "4"
 awc = { version = "3", features = ["rustls"] }
+chrono = { version = "0.4.30", features = ["serde"] }
 dotenvy = "0.15"
 env_logger = "0.10"
 log = "0.4"
@@ -22,6 +23,5 @@ serde = { version = "1.0", features = ["derive"] }
 serde_json = "1"
 serde_urlencoded = "0.7.1"
 sha2 = "0.10"
-sqlx = { version = "0.7", features = ["postgres", "runtime-tokio-rustls", "uuid", "time"] }
-time = { version = "0.3.25", features = ["serde", "macros"] }
+sqlx = { version = "0.7", features = ["postgres", "runtime-tokio-rustls", "uuid", "chrono"] }
 uuid = { version = "1.4", features = ["serde", "v4"] }

--- a/src/api/scopes/auth.rs
+++ b/src/api/scopes/auth.rs
@@ -3,7 +3,6 @@ use crate::models::SlackBot;
 use crate::SimilariumError;
 use actix_web::{get, web, HttpResponse, Scope};
 use serde::Deserialize;
-use time::OffsetDateTime;
 
 #[derive(Deserialize, Debug)]
 struct OAuthRedirect {
@@ -35,7 +34,7 @@ async fn get_oauth_redirect(
         bot_user_id: payload.bot_user_id,
         bot_scopes: payload.scope,
         is_enterprise_install: payload.is_enterprise_install,
-        installed_at: OffsetDateTime::now_utc(),
+        installed_at: chrono::Utc::now(),
         bot_id: None,
         bot_refresh_token: None,
         bot_token_expires_at: None,

--- a/src/api/scopes/commands.rs
+++ b/src/api/scopes/commands.rs
@@ -6,7 +6,6 @@ use crate::payloads::CommandPayload;
 use crate::slack_client::{Block, SlackClient};
 use crate::{SimilariumError, SimilariumErrorType};
 use actix_web::{post, web, HttpResponse, Scope};
-use time::macros::{datetime, format_description};
 use uuid::Uuid;
 
 #[post("/similarium")]
@@ -27,11 +26,10 @@ async fn post_similarium_command(
                 .await?;
         }
         Command::Start(time) => {
-            let format = format_description!("[hour]:[minute]");
             app_state
                 .slack_client
                 .post_message(
-                    &format!("Starting the game at {}", time.format(&format)?),
+                    &format!("Starting the game at {}", time.format("%H:%M")),
                     &payload.channel_id,
                     &token,
                     None,
@@ -98,8 +96,8 @@ async fn manual_start(
     };
     target_word.create_materialised_view(db).await?;
 
-    let datetime = datetime!(2023-08-08 00:00:00 UTC);
-    let header_text = get_header_text(datetime).unwrap();
+    let datetime = datetime!(2023, 8, 8);
+    let header_text = get_header_text(datetime);
 
     log::debug!("Setting up the game");
     let mut game = Game {

--- a/src/api/utils.rs
+++ b/src/api/utils.rs
@@ -1,12 +1,12 @@
 use crate::SimilariumError;
-use time::{macros::format_description, Time};
+use chrono::NaiveTime;
 
 #[derive(Debug, Eq, PartialEq)]
 pub enum Command {
     Help,
     ManualStart,
     ManualEnd,
-    Start(Time),
+    Start(NaiveTime),
     Stop,
     Invalid(String),
 }
@@ -18,7 +18,7 @@ pub fn parse_command(text: &str) -> Result<Command, SimilariumError> {
             if time.is_empty() {
                 return validation_error!("You must specify a time to start the game every day");
             }
-            match Time::parse(time, &format_description!("[hour]:[minute]")) {
+            match chrono::NaiveTime::parse_from_str(time, "%H:%M") {
                 Ok(time) => Command::Start(time),
                 Err(_) => Command::Invalid(format!("Invalid time: {time}")),
             }
@@ -38,7 +38,6 @@ mod tests {
     use super::*;
 
     use crate::SimilariumErrorType;
-    use time::macros::time;
 
     #[test]
     fn test_parse_command() {
@@ -86,7 +85,7 @@ mod tests {
     fn test_parse_command_start_parses_time_correctly() {
         assert_eq!(
             parse_command("start 23:59").unwrap(),
-            Command::Start(time!(23:59))
+            Command::Start(NaiveTime::from_hms_opt(23, 59, 0).unwrap())
         );
     }
 

--- a/src/error.rs
+++ b/src/error.rs
@@ -180,6 +180,7 @@ impl From<std::io::Error> for SimilariumError {
     }
 }
 
+/*
 impl From<time::error::InvalidFormatDescription> for SimilariumError {
     fn from(error: time::error::InvalidFormatDescription) -> Self {
         log::error!("Error parsing time: {}", error);
@@ -199,3 +200,4 @@ impl From<time::error::Format> for SimilariumError {
         }
     }
 }
+*/

--- a/src/game/utils.rs
+++ b/src/game/utils.rs
@@ -1,38 +1,35 @@
 use crate::models::{Game, GuessContextOrder};
 use crate::slack_client::Block;
 use crate::SimilariumError;
-use time::{
-    macros::{datetime, format_description},
-    OffsetDateTime,
-};
+use chrono::{DateTime, Utc};
 
-const BASE_DATE: OffsetDateTime = datetime!(2022-05-06 00:00:00 UTC);
+fn get_base_date() -> DateTime<Utc> {
+    datetime!(2022, 5, 6, 0, 0, 0)
+}
 
 /// Return a puzzle number for today
 ///
 /// The puzzle number is the number of days that have passed since Similarium started, which was
 /// the 6th of May 2022
-pub fn get_puzzle_number(date: OffsetDateTime) -> i64 {
-    let delta = date - BASE_DATE;
+pub fn get_puzzle_number(date: DateTime<Utc>) -> i64 {
+    let delta = date - get_base_date();
 
-    delta.whole_days()
+    delta.num_days()
 }
 /// Return the date of a puzzle
 ///
 /// The puzzle date is a nicely formatted date for the puzzle number, such as "Sunday November 13"
 /// for puzzle 191
-pub fn get_puzzle_date(puzzle_number: i64) -> Result<String, time::Error> {
-    let base_date = BASE_DATE + time::Duration::days(puzzle_number);
-    let format = format_description!("[weekday] [month repr:long] [day padding:none]");
-
-    Ok(base_date.format(&format)?.to_string())
+pub fn get_puzzle_date(puzzle_number: i64) -> String {
+    let base_date = get_base_date() + chrono::Duration::days(puzzle_number);
+    base_date.format("%A %B %-d").to_string()
 }
 
 /// Generate the header for the puzzle of the day
-pub fn get_header_text(date: OffsetDateTime) -> Result<String, time::Error> {
+pub fn get_header_text(date: DateTime<Utc>) -> String {
     let puzzle_number = get_puzzle_number(date);
-    let puzzle_date = get_puzzle_date(puzzle_number)?;
-    Ok(format!("{puzzle_date} - Puzzle number {puzzle_number}"))
+    let puzzle_date = get_puzzle_date(puzzle_number);
+    format!("{puzzle_date} - Puzzle number {puzzle_number}")
 }
 
 /// Generate header body of a game for Slack message
@@ -90,37 +87,34 @@ mod tests {
     #[test]
     fn test_get_puzzle_number() {
         // One day after the game started
-        let datetime = datetime!(2022-05-07 00:00:00 UTC);
+        let datetime = datetime!(2022, 5, 7);
 
         // Game start was considered puzzle 0
         assert_eq!(get_puzzle_number(datetime), 1);
 
         // Way later, to confirm the puzzle number matches the current date as this test was
         // written
-        let datetime = datetime!(2022-11-13 00:00:00 UTC);
+        let datetime = datetime!(2022, 11, 13);
         assert_eq!(get_puzzle_number(datetime), 191);
     }
 
     #[test]
     fn test_get_puzzle_date() {
-        assert_eq!(get_puzzle_date(1).unwrap(), String::from("Saturday May 7"));
-        assert_eq!(
-            get_puzzle_date(191).unwrap(),
-            String::from("Sunday November 13")
-        );
+        assert_eq!(get_puzzle_date(1), String::from("Saturday May 7"));
+        assert_eq!(get_puzzle_date(191), String::from("Sunday November 13"));
     }
 
     #[test]
     fn test_get_header_text() {
-        let datetime = datetime!(2022-05-07 00:00:00 UTC);
+        let datetime = datetime!(2022, 5, 7);
         assert_eq!(
-            get_header_text(datetime).unwrap(),
+            get_header_text(datetime),
             String::from("Saturday May 7 - Puzzle number 1")
         );
 
-        let datetime = datetime!(2022-11-13 00:00:00 UTC);
+        let datetime = datetime!(2022, 11, 13);
         assert_eq!(
-            get_header_text(datetime).unwrap(),
+            get_header_text(datetime),
             String::from("Sunday November 13 - Puzzle number 191")
         );
     }

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -43,6 +43,23 @@ macro_rules! slack_api_error {
     };
 }
 
+macro_rules! datetime {
+    ($year:expr, $month:expr, $day:expr) => {
+        chrono::NaiveDate::from_ymd_opt($year, $month, $day)
+            .unwrap()
+            .and_hms_opt(0, 0, 0)
+            .unwrap()
+            .and_utc()
+    };
+    ($year:expr, $month:expr, $day:expr, $hour:expr, $minute:expr, $second:expr) => {
+        chrono::NaiveDate::from_ymd_opt($year, $month, $day)
+            .unwrap()
+            .and_hms_opt($hour, $minute, $second)
+            .unwrap()
+            .and_utc()
+    };
+}
+
 #[cfg(test)]
 mod test {
     use crate::{SimilariumError, SimilariumErrorType};

--- a/src/models/slack_bot.rs
+++ b/src/models/slack_bot.rs
@@ -1,5 +1,4 @@
 use serde::{Deserialize, Serialize};
-use time::OffsetDateTime;
 use uuid::Uuid;
 
 #[derive(Debug, Deserialize, Serialize, sqlx::FromRow)]
@@ -15,9 +14,9 @@ pub struct SlackBot {
     pub bot_user_id: Option<String>,
     pub bot_scopes: Option<String>,
     pub bot_refresh_token: Option<String>,
-    pub bot_token_expires_at: Option<OffsetDateTime>,
+    pub bot_token_expires_at: Option<chrono::DateTime<chrono::Utc>>,
     pub is_enterprise_install: bool,
-    pub installed_at: OffsetDateTime,
+    pub installed_at: chrono::DateTime<chrono::Utc>,
 }
 
 impl SlackBot {


### PR DESCRIPTION
This basically reverts #7, going back to use `chrono` for time bassed functonality. `chrono` is a very common library used in multiple other libraries unfortunately, and in other piece of work I need a dependency that causes `chrono` to be installed and affect the behaviour of `sqlx`.

Given that `chrono` is being updated recently and has dropped the `time 0.1` dependency (which was the original reason for #7), I feel that it's safe to go back to use `chronos `