### PR TITLE
use vendored openssl for reqwest

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1445,6 +1445,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ff011a302c396a5197692431fc1948019154afc178baf7d8e37367442a4601cf"
 
 [[package]]
+name = "openssl-src"
+version = "300.1.3+3.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cd2c101a165fff9935e34def4669595ab1c7847943c42be86e21503e482be107"
+dependencies = [
+ "cc",
+]
+
+[[package]]
 name = "openssl-sys"
 version = "0.9.93"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1452,6 +1461,7 @@ checksum = "db4d56a4c0478783083cfafcc42493dd4a981d41669da64b4572a2a089b51b1d"
 dependencies = [
  "cc",
  "libc",
+ "openssl-src",
  "pkg-config",
  "vcpkg",
 ]
@@ -2044,6 +2054,7 @@ dependencies = [
  "fang",
  "log",
  "num-format",
+ "openssl",
  "phf",
  "rand",
  "rand_pcg",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,6 +17,7 @@ env_logger = "0.10"
 fang = { version = "0.10.4", default-features=false, features = ["asynk", "derive-error"] }
 log = "0.4"
 num-format = "0.4.4"
+openssl = { version = "0.10.57", features = ["vendored"] }
 phf = { version = "0.11.2", features = ["macros"] }
 rand = "0.8"
 rand_pcg = "0.3.1"


### PR DESCRIPTION
Fixes the issue where the Dockerfile will not build. Tried apt installing `libssl-dev` as suggested in some help posts, but couldn't get it to work. This unblocks for now at least.