### PR TITLE
Use cargo build instead of cargo install

### DIFF
--- a/.github/workflows/docker-publish-dev.yml
+++ b/.github/workflows/docker-publish-dev.yml
@@ -31,6 +31,6 @@ jobs:
         uses: docker/build-push-action@v5
         with:
           context: .
-          file: ./docker/Dockerfile
+          file: ./docker/Dockerfile.dev
           push: true
           tags: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:dev

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -16,10 +16,10 @@ COPY build.rs ./
 RUN cargo build --release --target x86_64-unknown-linux-musl --bin similarium
 
 FROM scratch
- 
+
 COPY --from=builder /usr/src/similarium/target/x86_64-unknown-linux-musl/release/similarium .
 COPY --from=builder /etc/ssl /etc/ssl
 USER 1000
 EXPOSE 8080
- 
+
 CMD ["./similarium"]

--- a/docker/Dockerfile.dev
+++ b/docker/Dockerfile.dev
@@ -7,13 +7,13 @@ RUN USER=root cargo new similarium
 WORKDIR /usr/src/similarium
 
 COPY Cargo.toml Cargo.lock ./
-RUN cargo build --release --target x86_64-unknown-linux-musl --bin similarium
+RUN cargo build --target x86_64-unknown-linux-musl --bin similarium
 
 COPY src ./src
 COPY .sqlx ./.sqlx
 COPY migrations ./migrations
 COPY build.rs ./
-RUN cargo build --release --target x86_64-unknown-linux-musl --bin similarium
+RUN cargo build --target x86_64-unknown-linux-musl --bin similarium
 
 FROM scratch
  


### PR DESCRIPTION
Also adds a non `--release`  build Dockerfile for the `:dev` tag