### PR TITLE
Add a nightly task to clean up materialised views

### DIFF
--- a/.sqlx/query-d9a5dc082bf84e488cdffd2e534bf2c108352355ce3fcc0dd084c0291e891d90.json
+++ b/.sqlx/query-d9a5dc082bf84e488cdffd2e534bf2c108352355ce3fcc0dd084c0291e891d90.json
@@ -1,0 +1,20 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "\n            SELECT\n                matviewname\n            FROM\n                pg_matviews\n            WHERE\n                matviewname NOT IN (\n                    SELECT DISTINCT\n                        'word2vec_'||secret\n                    FROM\n                        game\n                    WHERE\n                        active=true\n                )\n            ",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "matviewname",
+        "type_info": "Name"
+      }
+    ],
+    "parameters": {
+      "Left": []
+    },
+    "nullable": [
+      true
+    ]
+  },
+  "hash": "d9a5dc082bf84e488cdffd2e534bf2c108352355ce3fcc0dd084c0291e891d90"
+}

--- a/src/tasks/minutely.rs
+++ b/src/tasks/minutely.rs
@@ -1,8 +1,7 @@
 use crate::{
     db::get_pool,
     game::{end_game, get_active_games_on_channel, start_game_on_channel},
-    models::Channel,
-    models::SlackBot,
+    models::{Channel, SlackBot},
     slack_client::SlackClient,
 };
 use chrono::Timelike;
@@ -41,9 +40,7 @@ impl AsyncRunnable for GameTask {
         // well and not blocking this task that runs every minute
         for channel in channels {
             // Check if there are any active games on the channel, and end them
-            let token = SlackBot::get_slack_bot_token(&channel.team_id, pool)
-                .await
-                .unwrap();
+            let token = SlackBot::get_slack_bot_token(&channel.team_id, pool).await?;
 
             let active_games = get_active_games_on_channel(pool, &channel.id).await?;
             let mut should_start_game = true;

--- a/src/tasks/mod.rs
+++ b/src/tasks/mod.rs
@@ -1,3 +1,5 @@
 mod minutely;
+mod nightly;
 
 pub use minutely::GameTask;
+pub use nightly::MatViewCleanupTask;

--- a/src/tasks/nightly.rs
+++ b/src/tasks/nightly.rs
@@ -1,0 +1,37 @@
+use crate::{db::get_pool, models::Word2Vec};
+use fang::{
+    async_trait,
+    asynk::async_queue::AsyncQueueable,
+    serde::{Deserialize, Serialize},
+    typetag, AsyncRunnable, FangError, Scheduled,
+};
+
+#[derive(Serialize, Deserialize, Debug)]
+#[serde(crate = "fang::serde")]
+pub struct MatViewCleanupTask {}
+
+#[typetag::serde]
+#[async_trait]
+impl AsyncRunnable for MatViewCleanupTask {
+    async fn run(&self, _queue: &mut dyn AsyncQueueable) -> Result<(), FangError> {
+        log::debug!("Running MatViewCleanup");
+        let pool = get_pool();
+
+        Word2Vec::cleanup_materialised_views(pool).await?;
+
+        Ok(())
+    }
+
+    fn uniq(&self) -> bool {
+        true
+    }
+
+    fn cron(&self) -> Option<Scheduled> {
+        let expression = "0 17 4 * * *".to_string();
+        Some(Scheduled::CronPattern(expression))
+    }
+
+    fn backoff(&self, attempt: u32) -> u32 {
+        u32::pow(2, attempt)
+    }
+}

--- a/src/workers.rs
+++ b/src/workers.rs
@@ -38,5 +38,11 @@ pub async fn ensure_recurring_tasks(mut queue: AsyncQueue<NoTls>) -> Result<(), 
         .schedule_task(&game_task as &dyn fang::AsyncRunnable)
         .await?;
 
+    log::info!("Scheduling MatViewCleanupTask to run nightly");
+    let cleanup_task = tasks::MatViewCleanupTask {};
+    queue
+        .schedule_task(&cleanup_task as &dyn fang::AsyncRunnable)
+        .await?;
+
     Ok(())
 }


### PR DESCRIPTION
resolves #104

Runs nightly at 4:17 and just drops all materialised views unless they have an active game using them.

I'm 99% sure it's a race condition that's being introduced here, but not sure..

I get a list of all inactive views, but there's a chance that a game gets started at the same time using that secret, before I drop it? 

I should look into Postgres locks for this