### PR TITLE
Skip running linting and testing on tag creation

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,6 +1,9 @@
-on: [push]
-
 name: Test and lint
+
+on:
+  push:
+    branches:
+      - '**'
 
 env:
   RUSTFLAGS: "-Cinstrument-coverage"


### PR DESCRIPTION
It's already run on all pushes, so running on tags just doubles the work